### PR TITLE
docs: fix to specify $XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Plugin with no prefix are enabled by default, there entry will be mixed in the s
 
 ## Theming
 
-Onagre will look for a theme file in `$XDG_CONFIG_DIR/onagre/theme.scss` and will fallback to the default theme if none
+Onagre will look for a theme file in `$XDG_CONFIG_HOME/onagre/theme.scss` and will fallback to the default theme if none
 is found or if your theme contains syntax errors. To ensure your theme is correctly formatted run `onagre` from the terminal.
 
 For a detailed guide refer to [wiki -> theming](https://github.com/oknozor/onagre/wiki/Theming)

--- a/docs/website/src/get-started.md
+++ b/docs/website/src/get-started.md
@@ -81,7 +81,7 @@ To get help about a plugin usage, just type "?" in Onagre to display the bundled
 
 ## Configuration and Theming
 
-Onagre will look for a theme file in `$XDG_CONFIG_DIR/onagre/theme.scss` and will fall back to the default theme if none
+Onagre will look for a theme file in `$XDG_CONFIG_HOME/onagre/theme.scss` and will fall back to the default theme if none
 is found or if your theme contains syntax errors. To ensure your theme is correctly formatted run `onagre` from the terminal.
 
 A `.scss` extension is used for configuration in order to get syntax highlighting,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ pub fn main() -> iced::Result {
     info!("Starting onagre");
     let cli = Cli::parse();
 
-    // User defined theme config, $XDG_CONFIG_DIR/onagre/theme.toml otherwise
+    // User defined theme config, $XDG_CONFIG_HOME/onagre/theme.toml otherwise
     if let Some(theme_path) = cli.theme {
         let path = theme_path.canonicalize();
         if let Ok(path) = path {


### PR DESCRIPTION
https://codeberg.org/dirs/dirs-rs/src/commit/277838136f1920fe41f958171d3f2281475ac081/src/lib.rs#L93-L100

I noticed this typo when I addressed changing theme to apply https://github.com/onagre-launcher/onagre/issues/85#issuecomment-2410114650